### PR TITLE
Allow to add a basic auth on pages

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ class FlaskConfig(object):
 class ManifoldConfig(object):
     NGINX_CONF_PATH = os.environ.get('NGINX_CONF_PATH',
                                      '/etc/nginx/conf.d/default.conf')
+    NGINX_PASSWD_PATH = os.environ.get('NGINX_PASSWD_PATH')
     NGINX_CONTAINER = os.environ.get('NGINX_CONTAINER', 'manifoldoo_nginx_1')
     SUBDOMAIN = os.environ.get('SUBDOMAIN', 'manifold')
     DOMAIN = os.environ.get('DOMAIN', socket.gethostname())

--- a/manifold.py
+++ b/manifold.py
@@ -14,6 +14,8 @@ class Manifold():
 
     def reload_nginx(self):
         try:
+            # TODO: get the name of the container(s) with docker-compose:
+            # docker-compose ps -q nginx
             self.dock.kill(self.config.NGINX_CONTAINER,
                            'SIGHUP')
         except docker.errors.APIError as err:

--- a/nginx.py
+++ b/nginx.py
@@ -6,11 +6,10 @@ class NginxConfigRenderer():
     def __init__(self, manifold):
         self.manifold = manifold
         self.app = manifold.app
-        self.dock = manifold.dock
 
     def render(self, minions):
         with self.app.app_context():
-            return render_template('nginx.conf',
+            return render_template('nginx/nginx.conf',
                                    manifold=self.manifold,
                                    minions=minions)
 

--- a/templates/nginx/auth.conf
+++ b/templates/nginx/auth.conf
@@ -1,0 +1,7 @@
+{% if manifold.config.NGINX_PASSWD_PATH %}
+  satisfy any;
+  allow 127.0.0.1;
+  deny all;
+  auth_basic "Restricted Content";
+  auth_basic_user_file {{ manifold.config.NGINX_PASSWD_PATH }};
+{% endif %}

--- a/templates/nginx/minion.conf
+++ b/templates/nginx/minion.conf
@@ -1,0 +1,16 @@
+{% if minion.port and minion.ip %}
+  server {
+      listen 80;
+      server_name {{ minion.nginx_server_name }};
+
+      {% include 'nginx/auth.conf' %}
+
+      location / {
+        proxy_pass http://{{ minion.ip }}:{{ minion.port }};
+        # proxy_redirect {{ minion.host }}:{{ minion.port }}/ https://$host:$server_port/;
+      }
+    {% if minion.longpolling_port %}
+      location /longpolling { proxy_pass {{ minion.longpolling_host }}:{{ minion.longpolling_port }} ; }
+    {% endif %}
+  }
+{% endif %}

--- a/templates/nginx/nginx.conf
+++ b/templates/nginx/nginx.conf
@@ -2,6 +2,7 @@
 server {
     listen 80;
     server_name {{ manifold.nginx_server_name }};
+    {% include 'nginx/auth.conf' %}
     location / {
       proxy_pass http://{{ manifold.hostname }}:{{ manifold.port }};
     }
@@ -11,24 +12,13 @@ server {
          expires                 864000;
          proxy_pass http://{{ manifold.hostname }}:{{ manifold.port }};
     }
+    location ~ /\. {
+      deny all;
+    }
     proxy_set_header Host            $host;
     proxy_set_header X-Forwarded-For $remote_addr;
 }
-
 # configuration for the minions
 {% for minion in minions %}
-  {% if minion.port and minion.ip %}
-    server {
-        listen 80;
-        server_name {{ minion.nginx_server_name }};
-        location / {
-          proxy_pass http://{{ minion.ip }}:{{ minion.port }};
-          # proxy_redirect {{ minion.host }}:{{ minion.port }}/ https://$host:$server_port/;
-        }
-      {% if minion.longpolling_port %}
-        location /longpolling { proxy_pass {{ minion.longpolling_host }}:{{ minion.longpolling_port }} ; }
-      {% endif %}
-    }
-  {% endif %}
-
+  {% include 'nginx/minion.conf' %}
 {% endfor %}


### PR DESCRIPTION
An environment variable 'NGINX_PASSWD_PATH' with the absolute path of
the .htpasswd file must be set to activate the Basic Auth.
If the environment variable is not, Manifold and its Minions are allowed
to anyone.
